### PR TITLE
Added custom card info for discovery in dashboard

### DIFF
--- a/dist/refreshable-picture-card.js
+++ b/dist/refreshable-picture-card.js
@@ -155,4 +155,12 @@ class ResfeshablePictureCard extends HTMLElement {
 
 }
 
+window.customCards = window.customCards || []
+window.customCards.push({
+  type: 'refreshable-picture-card',
+  name: 'Refreshable Picture Card',
+  description: 'A picture that can be loaded from url or entity attribute and refreshed every N seconds',
+  preview: true,
+  documentationURL: 'https://github.com/dimagoltsman/refreshable-picture-card'
+})
 customElements.define('refreshable-picture-card', ResfeshablePictureCard);


### PR DESCRIPTION
This will allow the card to be searchable in the add card dialog box. I can not seem to get a preview image to display in the dialog box, but it does display the description text from this change. 

Prior to this change, it was necessary for a person to enter the code directly instead of being able to browse for the card and selecting it. (i.e. one needed to know that the card was available rather than see it in the list of cards). 