### PR TITLE
Use text entities directly without an attribute

### DIFF
--- a/dist/refreshable-picture-card.js
+++ b/dist/refreshable-picture-card.js
@@ -120,12 +120,15 @@ class ResfeshablePictureCard extends HTMLElement {
     
     let refreshTime = config.update_interval || 30
     
-    
+    var pictureUrl;
     let refreshFunc = function(){
-      var pictureUrl = config.static_picture
+      pictureUrl = config.static_picture
       
       if(config.entity_picture){
-       pictureUrl = hassObj.states[config.entity_picture]["attributes"][config.attribute]
+       pictureUrl = hassObj.states[config.entity_picture].state
+       if(config.attribute){
+         pictureUrl = hassObj.states[config.entity_picture]["attributes"][config.attribute]
+       }
       
        
      }


### PR DESCRIPTION
In my case, I wanted to use the entity's state as the source for the image, but the current implementation only allows an attribute on the entity to be used as source. This defaults to the entity's state in case an attribute configuration was not provided.