### PR TITLE
allow for full-card images (no margin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ tap_action:
 
 ```
 
+no margin (full card picture) example:
+
+```
+type: 'custom:refreshable-picture-card'
+static_picture: http://192.168.1.174/weatherForecast/weather.jpg
+noMargin: true
+
+```
+
 navigate example (onclick, open url in new tab): 
 
 ```

--- a/dist/refreshable-picture-card.js
+++ b/dist/refreshable-picture-card.js
@@ -28,27 +28,33 @@ class ResfeshablePictureCard extends HTMLElement {
     
     let picture = this._getPictureUrl(config.static_picture);
     let title = config.title || ""
-    
-    let html = ""
-    if(!title){
-      html = "<br>"
-    }else{
-      html = `<p class="center txt">${title}</p><br>`
+
+    let html = "";    
+    if(!title && !config.noMargin){
+      html += `<br>`;
+    } else if(title) {
+      html += `<p class="center txt">${title}</p><br>`;
     }
     try{
         
-        html += `
-        <img id="thePic" class="center thePic" src="${picture}"  ></img>
-        <br>
-        `;
-        const css = `
+        html += `<img id="thePic" class="center thePic" src="${picture}"  ></img>`;
+        if(!config.noMargin === true) {
+          html+= `<br>`;
+        }
+        let css = `
           .center{
             display: block;
             margin-top: auto;
             margin-bottom: auto;
             margin-left: auto;
             margin-right: auto;
-            width: 90%;
+        `;
+        if(config.noMargin) {
+          css+=`width: 100%`;
+        }else {
+          css+=`width: 90%`;
+        }
+        css+= `    
           }
           .txt{
             color: var(--ha-card-header-color, --primary-text-color);


### PR DESCRIPTION
adds a "noMargin" config option (defaults to false) that, when set to true) removes all top, bottom, left and right margins around the image to allow it to stretch the entire size of the card.