### PR TITLE
Major refactor + graphical config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,94 +1,101 @@
 # Refreshable Picture card #
 
-
 <img src="https://github.com/dimagoltsman/refreshable-picture-card/raw/master/example1.png" height="400">
 
 <img src="https://github.com/dimagoltsman/refreshable-picture-card/raw/master/example2.png" height="400">
 
-```
+```yaml
 resources:
   - url: /hacsfiles/refreshable-picture-card/refreshable-picture-card.js
     type: module
 ```
 
+Configuration is very easy, and can be done graphically.
 
-configuration is very easy. you can set a picture from a URL or a picture from an entity attribute
+You can set a picture from a URL or a picture from an entity attribute.
 
-attribute picture example:
+|        Name        |                        Description                        |             Required             |
+| ------------------ | --------------------------------------------------------- | -------------------------------- |
+| `title`            | Cart title                                                | no                               |
+| `refresh_interval` | Time in seconds between refreshes. Defaults to 30 seconds | yes                              |
+| `url`              | URL of the picture. Can be a local path.                  | mutually exclusive with `entity` |
+| `entity`           | Picture entity                                            | mutually exclusive with `url`    |
+| `attribute`        | Entity attribute                                          | no                               |
+| `tap_action`       | Action on tap                                             | no                               |
 
-```
+Attribute picture example:
+
+```yaml
 type: 'custom:refreshable-picture-card'
 title: My Mibox
-update_interval: 3 # default is 30
-entity_picture: media_player.livingroom_mibox
+refresh_interval: 3
+entity: media_player.livingroom_mibox
 attribute: entity_picture
-
 ```
 
 url image example:
-```
+
+```yaml
 type: 'custom:refreshable-picture-card'
 title: My Mibox
-update_interval: 3 # default is 30
-static_picture: /api/media_player_proxy/media_player.livingroom_mibox?token=11111111111111222222222233333333&cache=1589898123.724253
-
+refresh_interval: 3
+url: /api/media_player_proxy/media_player.livingroom_mibox?token=11111111111111222222222233333333&cache=1589898123.724253
 ```
 
-reolink camera snap url example:
+Reolink camera snap url example:
 
-```
+```yaml
 type: 'custom:refreshable-picture-card'
 title: Reolink Camera
-update_interval: 1
-static_picture: http://192.168.1.174/cgi-bin/api.cgi?cmd=Snap&channel=0&rs=someString&user=username&password=password
-
+refresh_interval: 1
+url: http://192.168.1.174/cgi-bin/api.cgi?cmd=Snap&channel=0&rs=someString&user=username&password=password
 ```
 
-tap action example: 
+Tap action example:
 
-```
+```yaml
 type: 'custom:refreshable-picture-card'
 title: Reolink Camera
-update_interval: 1
-static_picture: http://192.168.1.174/cgi-bin/api.cgi?cmd=Snap&channel=0&rs=someString&user=username&password=password
+refresh_interval: 1
+url: http://192.168.1.174/cgi-bin/api.cgi?cmd=Snap&channel=0&rs=someString&user=username&password=password
 tap_action:
-  call: remote.send_command
+  action: call-service
+  service: remote.send_command
   data:
     entity_id: remote.living_room_remote
     command: b64:JgCgAJSSEg8QEBIPERAPMhEyDxERDxAxEDESLxAyEREPEREQEBAQlBARDxIQEBAREi8PMhEvEhAQMRExDzIREBARDhISDhAyEBEQEQ8REi8RAAdclJMRDxAREREPEREwEi8SEBARDzIQMhAwDzESEBARERAQEBKSEg8QEBAREREPMREyDjESDhIwETESLxEQEBEREBAQETAPERERERAQMRAADQUAAAAAAAAAAA==
-
 ```
 
 no margin (full card picture) example:
 
-```
+```yaml
 type: 'custom:refreshable-picture-card'
-static_picture: http://192.168.1.174/weatherForecast/weather.jpg
+url: http://192.168.1.174/weatherForecast/weather.jpg
 noMargin: true
-
 ```
 
-navigate example (onclick, open url in new tab): 
+navigate example (onclick, open url in new tab):
 
-```
+```yaml
 type: 'custom:refreshable-picture-card'
 title: Reolink Camera
-update_interval: 1
-static_picture: http://192.168.1.174/cgi-bin/api.cgi?cmd=Snap&channel=0&rs=someString&user=username&password=password
-navigate: https://github.com/dimagoltsman/refreshable-picture-card/
+refresh_interval: 1
+url: http://192.168.1.174/cgi-bin/api.cgi?cmd=Snap&channel=0&rs=someString&user=username&password=password
+tap_action:
+  action: url
+  url_path: https://github.com/dimagoltsman/refreshable-picture-card/
 ```
-navigate_local example (onclick, change local/lovelace tab): 
 
-```
+navigate_local example (onclick, change local/lovelace tab):
+
+```yaml
 type: 'custom:refreshable-picture-card'
 title: Reolink Camera
-update_interval: 1
-static_picture: http://192.168.1.174/cgi-bin/api.cgi?cmd=Snap&channel=0&rs=someString&user=username&password=password
-navigate_local: camera
+refresh_interval: 1
+url: http://192.168.1.174/cgi-bin/api.cgi?cmd=Snap&channel=0&rs=someString&user=username&password=password
+tap_action:
+  action: navigate
+  navigation_path: camera
 ```
-
 
 # you are also welcome to contribute #
-
-
-

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ You can set a picture from a URL or a picture from an entity attribute.
 | `entity`           | Picture entity                                            | mutually exclusive with `url`    |
 | `attribute`        | Entity attribute                                          | no                               |
 | `tap_action`       | Action on tap                                             | no                               |
+| `noMargin`         | Whether to disable the margin around the picture.         | no                               |
 
 Attribute picture example:
 

--- a/dist/refreshable-picture-card-editor.js
+++ b/dist/refreshable-picture-card-editor.js
@@ -1,0 +1,122 @@
+import {
+  LitElement,
+  html,
+  css,
+} from "https://unpkg.com/lit-element@2.0.1/lit-element.js?module";
+import { fireEvent } from "./utils.js";
+
+const SCHEMA = [
+  { name: "title", selector: { text: {} } },
+  { name: "url", selector: { text: {} } },
+  {
+    name: "",
+    type: "grid",
+    schema: [
+      { name: "entity", selector: { entity: {} } },
+      {
+        name: "attribute",
+        selector: { attribute: { entity_id: "" } },
+        context: { filter_entity: "entity" },
+      },
+    ],
+  },
+  {
+    name: "",
+    type: "grid",
+    schema: [{ name: "tap_action", selector: { "ui-action": {} } }],
+  },
+  {
+    name: "refresh_interval",
+    required: true,
+    selector: { number: { min: 1 } },
+  },
+  { name: "noMargin", selector: { boolean: {} } },
+];
+
+class ResfeshablePictureCardEditor extends LitElement {
+  static properties = {
+    hass: {},
+    _config: {},
+  };
+
+  setConfig(config) {
+    this._config = config;
+  }
+
+  render() {
+    if (!this.hass || !this._config) {
+      return html``;
+    }
+
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${this._config}
+        .schema=${SCHEMA}
+        .computeLabel=${this._computeLabelCallback}
+        @value-changed=${this._valueChanged}
+      />
+    `;
+  }
+
+  _valueChanged = (ev) =>
+    fireEvent(this, "config-changed", { config: ev.detail.value });
+
+  _computeLabelCallback = (schema) => {
+    const { name } = schema;
+    switch (name) {
+      case "noMargin":
+        return "Remove margin";
+      // return this.hass.localize(
+      //   `refreshable-picture-card.${name}`
+      // );
+      case "refresh_interval":
+        return this.hass.localize(
+          `ui.panel.lovelace.editor.card.generic.${name}`
+        );
+      default:
+        return `${this.hass.localize(
+          `ui.panel.lovelace.editor.card.generic.${name}`
+        )} (${this.hass.localize(
+          "ui.panel.lovelace.editor.card.config.optional"
+        )})`;
+    }
+  };
+
+  static styles = css`
+    .card-config {
+      /* Cancels overlapping Margins for HAForm + Card Config options */
+      overflow: auto;
+    }
+    ha-switch {
+      padding: 16px 6px;
+    }
+    .side-by-side {
+      display: flex;
+      align-items: flex-end;
+    }
+    .side-by-side > * {
+      flex: 1;
+      padding-right: 8px;
+    }
+    .side-by-side > *:last-child {
+      flex: 1;
+      padding-right: 0;
+    }
+    .suffix {
+      margin: 0 8px;
+    }
+    hui-action-editor,
+    ha-select,
+    ha-textfield,
+    ha-icon-picker {
+      margin-top: 8px;
+      display: block;
+    }
+  `;
+}
+
+customElements.define(
+  "refreshable-picture-card-editor",
+  ResfeshablePictureCardEditor
+);

--- a/dist/refreshable-picture-card.js
+++ b/dist/refreshable-picture-card.js
@@ -1,195 +1,145 @@
+import {
+  LitElement,
+  html,
+  css,
+} from "https://unpkg.com/lit-element@2.0.1/lit-element.js?module";
+import "./refreshable-picture-card-editor.js";
+import { handleAction } from "./utils.js";
 
-var hassObj = null;
-class ResfeshablePictureCard extends HTMLElement {
+class ResfeshablePictureCard extends LitElement {
+  static properties = {
+    hass: {},
+    config: {},
+    pictureUrl: {},
+  };
+
+  _refreshInterval;
 
   constructor() {
     super();
-    this.attachShadow({ mode: 'open' });
+    this.pictureUrl = "";
   }
+
+  static getConfigElement() {
+    return document.createElement("refreshable-picture-card-editor");
+  }
+
+  static getStubConfig() {
+    return {
+      type: "custom:refreshable-picture-card",
+      title: "Refreshable Picture",
+      refresh_interval: 30,
+      url: "",
+      entity: "",
+      attribute: "",
+      noMargin: true,
+      tap_action: { action: "none" },
+    };
+  }
+
   setConfig(config) {
-    
-    const root = this.shadowRoot;
-    if (root.lastChild) root.removeChild(root.lastChild);
-
-    const cardConfig = Object.assign({}, config);
-    this._config = cardConfig
+    if (!config.url && !config.entity) {
+      throw new Error("You need to define either a url or an entity");
+    }
+    if (config.url && config.entity) {
+      throw new Error("You need to define only one of url or entity");
+    }
+    this.config = config;
+    const refreshTime = (config.refresh_interval || 30) * 1000;
+    clearInterval(this._refreshInterval);
+    this._refreshInterval = setInterval(
+      () => (this.pictureUrl = this._getTimestampedUrl()),
+      refreshTime
+    );
+    this.pictureUrl = this._getTimestampedUrl();
   }
 
- 
-  
-  set hass(hass) {
-    
-    hassObj = hass;
-
-  
-    const config = this._config;
-    
-    // console.log(hassObj.states[config.entity_picture]["attributes"][config.attribute])
-    
-    let picture = this._getPictureUrl(config.static_picture);
-    let title = config.title || ""
-
-    let html = "";    
-    if(!title && !config.noMargin){
-      html += `<br>`;
-    } else if(title) {
-      html += `<p class="center txt">${title}</p><br>`;
-    }
-    try{
-        
-        html += `<img id="thePic" class="center thePic" src="${picture}"  ></img>`;
-        if(!config.noMargin === true) {
-          html+= `<br>`;
-        }
-        let css = `
-          .center{
-            display: block;
-            margin-top: auto;
-            margin-bottom: auto;
-            margin-left: auto;
-            margin-right: auto;
-            background: var( --ha-card-background, var(--card-background-color, white) );
-            box-shadow: var(--ha-card-box-shadow, none);
-            box-sizing: border-box;
-            border-width: var(--ha-card-border-width, 1px);
-            border-style: solid;
-            border-color: var( --ha-card-border-color, var(--divider-color, #e0e0e0) );
-            color: var(--primary-text-color);
-            transition: all 0.3s ease-out 0s;
-            position: relative;
-            border-radius: var(--ha-card-border-radius, 12px); 
-        `;
-        if(config.noMargin) {
-          css+=`width: 100%`;
-        }else {
-          css+=`width: 90%`;
-        }
-        css+= `    
-          }
-          .txt{
-            color: var(--ha-card-header-color, --primary-text-color);
-            font-family: var(--ha-card-header-font-family, inherit);
-            font-size: var(--ha-card-header-font-size, 24px);
-            letter-spacing: -0.012em;
-            line-height: 32px;
-          }
-          
-        `;
-  
-        
-        const root = this.shadowRoot;
-        this._hass = hass;
-        // root.lastChild.hass = hass;
-   
-        const card = document.createElement('ha-card');
-        if(!this.content){
-             this.content = document.createElement('div');
-             const style = document.createElement('style');
-             
-  
-             style.textContent = css;
-             this.content.innerHTML = html;
-             card.appendChild(this.content);
-             card.appendChild(style);
-             
-             root.appendChild(card);
-             card.onclick = function(){
-                if(config.tap_action){
-                  let domain = config.tap_action.call.split(".")[0]
-                  let action = config.tap_action.call.split(".")[1]
-                   console.log(config.tap_action.data);
-                   hass.callService(domain,
-                            action, 
-                            config.tap_action.data
-                             );
-                }else if(config.navigate){
-                  window.open(config.navigate);
-                }else if(config.navigate_local){
-                  window.location.assign(config.navigate_local);
-                }
-              
-              };
-              this._bindrefresh(card, this._hass, this._config, this._getPictureUrl);
-              
-              window[`scriptLoaded`] = true
-        }
-    
-    } catch(err){
-      console.log(err)
-      console.log('waiting for refreshable-picture-card to load');
-    }
-    
+  render() {
+    const { noMargin, title } = this.config;
+    return html`
+      <ha-card header=${title} @click="${this._onClick}">
+        <div class=${noMargin ? "withoutMargin" : "withMargin"}>
+          <img class="center" src="${this.pictureUrl}" />
+        </div>
+      </ha-card>
+    `;
   }
-  
-  _makeid(length) {
-   var result           = '';
-   var characters       = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-   var charactersLength = characters.length;
-   for ( var i = 0; i < length; i++ ) {
-      result += characters.charAt(Math.floor(Math.random() * charactersLength));
-   }
-   return result;
-}
- 
-    
-  _bindrefresh(card, hass, config, getPictureUrl){
-    var picture =  card.getElementsByClassName(`thePic`)[0];
-  
-    
-    let refreshTime = config.update_interval || 30
-    
-    var pictureUrl;
-    let refreshFunc = function(){
-      pictureUrl = config.static_picture
-      
-      if(config.entity_picture){
-       pictureUrl = hassObj.states[config.entity_picture].state
-       if(config.attribute){
-         pictureUrl = hassObj.states[config.entity_picture]["attributes"][config.attribute]
-       }
-      
-       
-     }
-     
-     if(window.getComputedStyle(picture).display){
-      
-      // console.log(pictureUrl)
-       picture.src = getPictureUrl(pictureUrl);
-    
-     }
-   
-       
-       setTimeout(refreshFunc, refreshTime * 1000)
-    }
-    
-    
-    refreshFunc();
 
+  _onClick() {
+    const { config, hass } = this;
+    const { tap_action } = config;
+    if (!tap_action) {
+      return;
+    }
+    handleAction(this, hass, config, tap_action);
   }
- 
-   _getPictureUrl(staticPictureUrl){
-      var pictureUrl = staticPictureUrl || "";
-      if(pictureUrl.indexOf("?") > -1){
-        pictureUrl = pictureUrl + "&currentTimeCache=" + (new Date().getTime())
-      }else{
-        pictureUrl = pictureUrl + "?currentTimeCache=" + (new Date().getTime())
-      }
-     return pictureUrl;
-   }
-  
+
+  static styles = css`
+    .center {
+      display: block;
+      margin-top: auto;
+      margin-bottom: auto;
+      margin-left: auto;
+      margin-right: auto;
+      background: var(
+        --ha-card-background,
+        var(--card-background-color, white)
+      );
+      box-shadow: var(--ha-card-box-shadow, none);
+      box-sizing: border-box;
+      border-width: var(--ha-card-border-width, 1px);
+      border-style: solid;
+      border-color: var(--ha-card-border-color, var(--divider-color, #e0e0e0));
+      color: var(--primary-text-color);
+      transition: all 0.3s ease-out 0s;
+      position: relative;
+      border-radius: var(--ha-card-border-radius, 12px);
+      width: 100%;
+    }
+    .withMargin {
+      margin: 5%;
+    }
+    .withoutMargin {
+      margin: 0;
+    }
+    .txt {
+      color: var(--ha-card-header-color, --primary-text-color);
+      font-family: var(--ha-card-header-font-family, inherit);
+      font-size: var(--ha-card-header-font-size, 24px);
+      letter-spacing: -0.012em;
+      line-height: 32px;
+    }
+  `;
+
+  _getPictureUrl() {
+    const { url, entity, attribute } = this.config;
+    if (!entity) {
+      return url;
+    }
+    const pictStates = this.hass.states[entity];
+    return attribute ? pictStates["attributes"][attribute] : pictStates.state;
+  }
+
+  _getTimestampedUrl() {
+    const url = this._getPictureUrl();
+    return url ? `${url}#${new Date().getTime()}` : "";
+  }
+
   getCardSize() {
     return 3;
   }
-  
-
 }
 
-window.customCards = window.customCards || []
-window.customCards.push({
-  type: 'refreshable-picture-card',
-  name: 'Refreshable Picture Card',
-  description: 'A picture that can be loaded from url or entity attribute and refreshed every N seconds',
+const cardDef = {
+  type: "refreshable-picture-card",
+  name: "Refreshable Picture Card",
+  description:
+    "A picture that can be loaded from url or entity attribute and refreshed every N seconds",
   preview: true,
-  documentationURL: 'https://github.com/dimagoltsman/refreshable-picture-card'
-})
-customElements.define('refreshable-picture-card', ResfeshablePictureCard);
+  documentationURL: "https://github.com/dimagoltsman/refreshable-picture-card",
+  configurable: true,
+};
+window.customCards = window.customCards || [];
+window.customCards.push(cardDef);
+
+customElements.define("refreshable-picture-card", ResfeshablePictureCard);

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -1,0 +1,95 @@
+// Common utilities functions shamelessly taken from lovelace-mushroom
+// Copyright Paul Bottein
+// https://github.com/piitaya/lovelace-mushroom
+
+export function handleAction(node, hass, config, actionConfig) {
+  switch (actionConfig.action) {
+    case "more-info": {
+      if (config.entity) {
+        fireEvent(node, "hass-more-info", { entityId: config.entity });
+      } else {
+        showToast(node, {
+          message: hass.localize(
+            "ui.panel.lovelace.cards.actions.no_entity_more_info"
+          ),
+        });
+        forwardHaptic("failure");
+      }
+      break;
+    }
+    case "navigate":
+      if (actionConfig.navigation_path) {
+        navigate(actionConfig.navigation_path);
+      } else {
+        showToast(node, {
+          message: hass.localize(
+            "ui.panel.lovelace.cards.actions.no_navigation_path"
+          ),
+        });
+        forwardHaptic("failure");
+      }
+      break;
+    case "url": {
+      if (actionConfig.url_path) {
+        window.open(actionConfig.url_path);
+      } else {
+        showToast(node, {
+          message: hass.localize("ui.panel.lovelace.cards.actions.no_url"),
+        });
+        forwardHaptic("failure");
+      }
+      break;
+    }
+    case "toggle": {
+      if (config.entity) {
+        toggleEntity(hass, config.entity);
+        forwardHaptic("light");
+      } else {
+        showToast(this, {
+          message: hass.localize(
+            "ui.panel.lovelace.cards.actions.no_entity_toggle"
+          ),
+        });
+        forwardHaptic("failure");
+      }
+      break;
+    }
+    case "call-service": {
+      if (!actionConfig.service) {
+        showToast(node, {
+          message: hass.localize("ui.panel.lovelace.cards.actions.no_service"),
+        });
+        forwardHaptic("failure");
+        return;
+      }
+      const [domain, service] = actionConfig.service.split(".", 2);
+      hass.callService(
+        domain,
+        service,
+        actionConfig.data ?? actionConfig.service_data,
+        actionConfig.target
+      );
+      forwardHaptic("light");
+      break;
+    }
+    case "fire-dom-event": {
+      fireEvent(node, "ll-custom", actionConfig);
+    }
+  }
+}
+
+const forwardHaptic = (hapticType) => fireEvent(window, "haptic", hapticType);
+
+const showToast = (el, params) => fireEvent(el, "hass-notification", params);
+
+export const fireEvent = (node, type, detail, options) => {
+  options = options || {};
+  const event = new Event(type, {
+    bubbles: options.bubbles === undefined ? true : options.bubbles,
+    cancelable: Boolean(options.cancelable),
+    composed: options.composed === undefined ? true : options.composed,
+  });
+  event.detail = detail;
+  node.dispatchEvent(event);
+  return event;
+};


### PR DESCRIPTION
Hi there, thanks for this card!

I took the liberty to go for a major ovrehaul (was starting to add a new feature, but then I saw the home assistant dev pages on custom component and I couldn't help it :sweat_smile:).

I turned the card class into a LitElement for some fancy stuff, and borrowed some lovelace-mushroom code to handle the boilerplate (mostly the tap_action related functions, that now can handle all the actions and not only the service call, fixin #20 with a single option).

I added the card editor element to be able to do graphical configuration. To leverage the localization already in place, I had to rename some of the configuration parameters. Everything is explained in the readme.

I don't have any entity that provides images, so some testing of the entity+attribute part might be needed.

Lastly, I changed the picture url querystring to a fragment (`#`) as cache invalidator [based on this](https://stackoverflow.com/a/9943419/4149512), It seems to work for me and might be gentler on some servers, but I can revert that part if it doesn't cut.
I wanted to add the ability to provide custom headers to fetch the images, and for that to work I would switch to a `fetch` and then pass the downloaded data in the `img` `src`, so the fragment is just a temporary thing anyway (It seemed to much to add to a single PR, though).