### PR TITLE
Call clearInterval on component disconnect (fixes #27)

### DIFF
--- a/dist/refreshable-picture-card.js
+++ b/dist/refreshable-picture-card.js
@@ -45,13 +45,25 @@ class ResfeshablePictureCard extends LitElement {
       throw new Error("You need to define only one of url or entity");
     }
     this.config = config;
-    const refreshTime = (config.refresh_interval || 30) * 1000;
+  }
+
+  connectedCallback() {
+    super.connectedCallback?.();
+
+    const refreshTime = (this.config.refresh_interval || 30) * 1000;
     clearInterval(this._refreshInterval);
     this._refreshInterval = setInterval(
       () => (this.pictureUrl = this._getTimestampedUrl()),
       refreshTime
     );
     this.pictureUrl = this._getTimestampedUrl();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback?.();
+    if (this._refreshInterval) {
+      clearInterval(this._refreshInterval);
+    }
   }
 
   render() {


### PR DESCRIPTION
Upsetting the issue #27 quite was... So here's an attempt to fix it :))
Web component's `connectedCallback` and `disconnectedCallback` methods seem to be the right place for setting/clearing photo updater interval. At least I haven't found any problems with it.
To get ahead of any questions, I tried creating the interval in `setConfig` without adding `connectedCallback` but it seems, when navigating through different tabs on a given dashboard, component instances are reused and `setConfig` isn't always called.