### PR TITLE
Use ? instead of # in generated urls to omit cache (fix #26)

### DIFF
--- a/dist/refreshable-picture-card.js
+++ b/dist/refreshable-picture-card.js
@@ -122,7 +122,7 @@ class ResfeshablePictureCard extends LitElement {
 
   _getTimestampedUrl() {
     const url = this._getPictureUrl();
-    return url ? `${url}#${new Date().getTime()}` : "";
+    return url ? `${url}?${new Date().getTime()}` : "";
   }
 
   getCardSize() {


### PR DESCRIPTION
As described in #26, auto-refresh doesn't work on all browsers (in my case Chromium based browsers). Here's a small suggestion how this could be fixed. Instead of `#`, use `?` when generating new URLs.
Another option would be to also name the GET param, i.e. `?v=2137000`.  A unique parameter name would have to be used. Any suggestions?