### PR TITLE
remove refresh duration slider

### DIFF
--- a/dist/refreshable-picture-card-editor.js
+++ b/dist/refreshable-picture-card-editor.js
@@ -28,7 +28,7 @@ const SCHEMA = [
   {
     name: "refresh_interval",
     required: true,
-    selector: { number: { min: 1 } },
+    selector: { number: { min: 1, mode: "box"} },
   },
   { name: "noMargin", selector: { boolean: {} } },
 ];


### PR DESCRIPTION
Closes #31

This is the quick fix that doesn't introduce breaking changes.

Let me know if you want to push this further, break things and use the duration selector instead (in a future pr)