### PR TITLE
Set initial URL after a brief delay to avoid this.hass being undefined

### DIFF
--- a/dist/refreshable-picture-card.js
+++ b/dist/refreshable-picture-card.js
@@ -49,20 +49,28 @@ class ResfeshablePictureCard extends LitElement {
 
   connectedCallback() {
     super.connectedCallback?.();
-
     const refreshTime = (this.config.refresh_interval || 30) * 1000;
-    clearInterval(this._refreshInterval);
+
+    if(this._refreshInterval) {
+      clearInterval(this._refreshInterval);
+    }
     this._refreshInterval = setInterval(
       () => (this.pictureUrl = this._getTimestampedUrl()),
       refreshTime
     );
-    this.pictureUrl = this._getTimestampedUrl();
+
+    // calling it after 10 ms ensures this.hass will be set
+    setTimeout(
+        () => (this.pictureUrl = this._getTimestampedUrl()),
+        10
+    );
   }
 
   disconnectedCallback() {
     super.disconnectedCallback?.();
     if (this._refreshInterval) {
       clearInterval(this._refreshInterval);
+      this._refreshInterval = undefined;
     }
   }
 


### PR DESCRIPTION
I don't know why but sometimes `this.hass` is not set at the time `connectedCallback()` is called:

```
Uncaught TypeError: this.hass is undefined
_getPictureUrl refreshable-picture-card.js:139
_getTimestampedUrl refreshable-picture-card.js:144
connectedCallback refreshable-picture-card.js:62
connectedCallback scoped-custom-element-registry.js:248
k lit-html.ts:1411
$ lit-html.ts:1454
g lit-html.ts:1563
```

It sometimes happened for me in the Firefox/MacOS but it happened almost every time in the Home Assistant companion app on Android. When it happened it caused the initial image URL not being loaded, so there was no image until the next timer interval.

Adding a brief delay fixed it.

Fixes #25