### PR TITLE
Detect expired URL in IMG tag and reload, avoid IMG tag with an empty src

### DIFF
--- a/dist/refreshable-picture-card.js
+++ b/dist/refreshable-picture-card.js
@@ -18,6 +18,7 @@ class ResfeshablePictureCard extends LitElement {
   constructor() {
     super();
     this.pictureUrl = "";
+    this.hasError = false;
   }
 
   static getConfigElement() {
@@ -66,12 +67,26 @@ class ResfeshablePictureCard extends LitElement {
     }
   }
 
+  onError() {
+    if (!this.hasError) {
+      this.hasError = true;
+      this.pictureUrl = this._getTimestampedUrl();
+    }
+  }
+
+  onLoad() {
+    this.hasError = false;
+  }
+
   render() {
     const { noMargin, title } = this.config;
     return html`
       <ha-card header=${title} @click="${this._onClick}">
         <div class=${noMargin ? "withoutMargin" : "withMargin"}>
-          <img class="center" src="${this.pictureUrl}" />
+          ${this.pictureUrl != '' ?
+            html`<img class="center" @error="${this.onError}" @load="${this.onLoad}" src="${this.pictureUrl}" />` :
+            ''
+          }
         </div>
       </ha-card>
     `;


### PR DESCRIPTION
When a dashboard with this component is opened in Home Assistant companion app (android) and put in the background (by pressing Home button or multi-tasking) and then opened again after couple of minutes, sometimes it would display a broken image symbol because the URL in the src attribute has expired in the meantime (token has expired).

This patch attempts to reload the image with a fresh token immediately. It does that only once to avoid a crazy loop of reloads for a broken link (for a permanently broken URL). A successful image load resets the error state and allows one additional reload again.