### PR TITLE
Static placeholder before refreshed image loads.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,16 @@ Configuration is very easy, and can be done graphically.
 
 You can set a picture from a URL or a picture from an entity attribute.
 
-|        Name        |                        Description                        |             Required             |
-| ------------------ | --------------------------------------------------------- | -------------------------------- |
-| `title`            | Cart title                                                | no                               |
-| `refresh_interval` | Time in seconds between refreshes. Defaults to 30 seconds | yes                              |
-| `url`              | URL of the picture. Can be a local path.                  | mutually exclusive with `entity` |
-| `entity`           | Picture entity                                            | mutually exclusive with `url`    |
-| `attribute`        | Entity attribute                                          | no                               |
-| `tap_action`       | Action on tap                                             | no                               |
-| `noMargin`         | Whether to disable the margin around the picture.         | no                               |
+|        Name        |                        Description                           |             Required             |
+| ------------------ | ------------------------------------------------------------ | -------------------------------- |
+| `title`            | Cart title                                                   | no                               |
+| `refresh_interval` | Time in seconds between refreshes. Defaults to 30 seconds    | yes                              |
+| `url`              | URL of the picture. Can be a local path.                     | mutually exclusive with `entity` |
+| `entity`           | Picture entity                                               | mutually exclusive with `url`    |
+| `attribute`        | Entity attribute                                             | no                               |
+| `tap_action`       | Action on tap                                                | no                               |
+| `noMargin`         | Whether to disable the margin around the picture.            | no                               |
+| `fallback_image`   | Optional URL of an image to show while refreshed image loads | no                               |
 
 Attribute picture example:
 
@@ -73,6 +74,16 @@ no margin (full card picture) example:
 type: 'custom:refreshable-picture-card'
 url: http://192.168.1.174/weatherForecast/weather.jpg
 noMargin: true
+```
+
+fallback image example (use a static placeholder while refreshed image is loading):
+
+```yaml
+type: 'custom:refreshable-picture-card'
+title: My Camera with Placeholder
+refresh_interval: 5
+url: /local/camera/snap.jpg
+fallback_image: /local/images/placeholder.png
 ```
 
 navigate example (onclick, open url in new tab):

--- a/dist/refreshable-picture-card-editor.js
+++ b/dist/refreshable-picture-card-editor.js
@@ -8,6 +8,7 @@ import { fireEvent } from "./utils.js";
 const SCHEMA = [
   { name: "title", selector: { text: {} } },
   { name: "url", selector: { text: {} } },
+  { name: "fallback_image", selector: { text: {} } },
   {
     name: "",
     type: "grid",
@@ -56,6 +57,16 @@ class ResfeshablePictureCardEditor extends LitElement {
         .computeLabel=${this._computeLabelCallback}
         @value-changed=${this._valueChanged}
       />
+      <!-- Explicit fallback_image field: some HA versions or themes may hide custom
+           ha-form fields — render a dedicated input so users always can set it. -->
+      <div style="margin-top:12px;">
+        <label style="display:block; font-size:14px; margin-bottom:6px;">${this._computeLabelCallback({name: 'fallback_image'})}</label>
+        <ha-textfield
+          .value=${this._config.fallback_image || ''}
+          @input=${this._fallbackInput}
+          placeholder="/local/placeholder.jpg or https://..."
+        ></ha-textfield>
+      </div>
     `;
   }
 
@@ -65,6 +76,8 @@ class ResfeshablePictureCardEditor extends LitElement {
   _computeLabelCallback = (schema) => {
     const { name } = schema;
     switch (name) {
+      case "fallback_image":
+        return "Fallback image (optional)";
       case "noMargin":
         return "Remove margin";
       // return this.hass.localize(
@@ -81,6 +94,18 @@ class ResfeshablePictureCardEditor extends LitElement {
           "ui.panel.lovelace.editor.card.config.optional"
         )})`;
     }
+  };
+
+  _fallbackInput = (ev) => {
+    const value = ev.target.value;
+    const cfg = { ...(this._config || {}) };
+    if (value === '') {
+      // remove the key when empty
+      delete cfg.fallback_image;
+    } else {
+      cfg.fallback_image = value;
+    }
+    fireEvent(this, 'config-changed', { config: cfg });
   };
 
   static styles = css`


### PR DESCRIPTION
Sometimes an image (for example big camera snapshot) takes a moment to load before it becomes clickable, for a tap action
This can set a placeholder image - preferably compressed lower quality image - that will be displayed until the refreshed image finishes loading and replaces it.